### PR TITLE
shiny + bugfix

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^\.Rproj\.user$
 ^data-raw$
 ^analyses$
+^shiny$

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,4 @@
+* added warning if not sufficient input are supplied (#11)
 * remove the needs to provide the intercept
 * fix bug found by DB that prevents `evaluate_at()` to work if
   no strata are provided to a bag (#10)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,4 @@
+* remove the needs to provide the intercept
 * fix bug found by DB that prevents `evaluate_at()` to work if
   no strata are provided to a bag (#10)
 * fix bug that prevents `evaluate_at()` to work if data supplied 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+* fix bug found by DB that prevents `evaluate_at()` to work if
+  no strata are provided to a bag (#10)
 * fix bug that prevents `evaluate_at()` to work if data supplied 
   strata not in the eqs_bag.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+* fix bug that prevents `evaluate_at()` to work if data supplied 
+  strata not in the eqs_bag.
+
 # equationer 0.1.3
 
 * fix bug which prevent `evaluate_at()` to works with bag which include

--- a/R/eqs_bag.R
+++ b/R/eqs_bag.R
@@ -114,9 +114,13 @@ eqs_bag <- function(...,
     strata_lst <- purrr::map(xs, get_strata) %>%
         purrr::flatten()
 
-    strata_names <- names(strata_lst) %>%
-        unique() %>%
-        purrr::set_names()
+    strata_names <- if (length(strata_lst)) {
+        names(strata_lst) %>%
+            unique() %>%
+            purrr::set_names()
+    } else {
+        c("a" = "a")[0]
+    }
 
     strata <- purrr::map(strata_names, ~{
         strata_lst[names(strata_lst) == .x] %>%

--- a/R/evaluate_at.R
+++ b/R/evaluate_at.R
@@ -45,6 +45,7 @@ evaluate_at <- function(x, ...) {
 evaluate_at.eq <- function(x, ...) {
 
     vs <- list(...)
+    vs <- vs[names(vs) %in% get_covariates(x)]
 
     if (!rlang::is_named(vs)) {
         ui_stop("Not all variable names are valid or non empty names")
@@ -53,6 +54,8 @@ evaluate_at.eq <- function(x, ...) {
     if (any(duplicated(names(vs)))) {
         ui_stop("Some variable names are duplicated.")
     }
+
+
 
     are_cov_num <- purrr::map_lgl(vs, is.numeric)
     if (!all(are_cov_num)) {

--- a/R/evaluate_at.R
+++ b/R/evaluate_at.R
@@ -45,7 +45,9 @@ evaluate_at <- function(x, ...) {
 evaluate_at.eq <- function(x, ...) {
 
     vs <- list(...)
-    vs <- vs[names(vs) %in% get_covariates(x)]
+    eq_cov <- get_covariates(x)
+
+    vs <- vs[names(vs) %in% eq_cov]
 
     if (!rlang::is_named(vs)) {
         ui_stop("Not all variable names are valid or non empty names")
@@ -66,7 +68,8 @@ evaluate_at.eq <- function(x, ...) {
         ))
     }
 
-    eq_cov <- get_covariates(x)
+    vs[["intercept"]] <- 1L
+
     cov_val_name <- names(vs)
 
     if (!is_applicable_to_covset(x, cov_val_name)) {
@@ -79,11 +82,13 @@ evaluate_at.eq <- function(x, ...) {
         ))
     }
 
+
+
     res <- unlist(vs[eq_cov]) %*% x %>%
         drop() %>%
         purrr::set_names(get_outcome(x))
 
-    dplyr::as_tibble(c(
+    res <- dplyr::as_tibble(c(
         vs,
         get_strata(x),
         list(
@@ -92,6 +97,9 @@ evaluate_at.eq <- function(x, ...) {
             eq_name = get_name(x)
         )
     ))
+
+    res[["intercept"]] <- NULL # not select in case it not exists
+    res
 }
 
 
@@ -146,6 +154,8 @@ evaluate_at.eqs <- function(x, ..., .outcome = NULL) {
 
     x_strata <- get_strata(x)
     x_strata_names <- names(x_strata)
+
+    vs[["intercept"]] <- 1L
 
     vs_strata_values <- vs[vs_names %in% x_strata_names]
     are_values_in_levels <- purrr::imap_lgl(vs_strata_values, ~{
@@ -209,13 +219,15 @@ evaluate_at.eqs <- function(x, ..., .outcome = NULL) {
         )
     }
 
-    dplyr::as_tibble(c(
+    res <- dplyr::as_tibble(c(
         res,
         list(
             eq_group = get_name(x),
             reference = get_reference(x)
         )
     ))
+    res[["intercept"]] <- NULL
+    res
 
 }
 
@@ -364,6 +376,8 @@ evaluate_at.eqs_bag <- function(x, ..., .outcome = NULL) {
         ui_stop("Some variable/strata names are duplicated.")
     }
 
+    vs[["intercept"]] <- 1L
+
     x_strata <- get_strata(x)
     x_strata_names <- names(x_strata)
 
@@ -417,6 +431,7 @@ evaluate_at.eqs_bag <- function(x, ..., .outcome = NULL) {
             ),
             .rows = 0
         )
+        res[["intercept"]] <- NULL
         return(res)
     }
 
@@ -442,8 +457,15 @@ evaluate_at.eqs_bag <- function(x, ..., .outcome = NULL) {
         ))
     )
 
-    if (length(res_lst) == 1) return(res_lst[[1]])
+    if (length(res_lst) == 1) {
+        res_lst[[1]][["intercept"]] <- NULL
+        return(res_lst[[1]])
+    }
 
-    suppressMessages(purrr::reduce(res_lst, dplyr::full_join))
+    suppressMessages(
+        res <- purrr::reduce(res_lst, dplyr::full_join)
+    )
+    res[["intercept"]] <- NULL
+    res
 }
 

--- a/shiny/equationer/equationer.Rproj
+++ b/shiny/equationer/equationer.Rproj
@@ -1,0 +1,16 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 4
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes

--- a/shiny/equationer/global.R
+++ b/shiny/equationer/global.R
@@ -1,0 +1,32 @@
+library(dplyr)
+library(shinyjs)
+library(DT)
+library(equationer)
+data("reer")
+
+
+
+activate_numeric_if_checked <- function(name, input, output, session) {
+    observeEvent(input[[paste0(name, "_tick")]], {
+        if (!input[[paste0(name, "_tick")]]) {
+            disable(name)
+            updateNumericInput(session, name, value = numeric())
+        } else {
+            enable(name)
+            updateNumericInput(session, name, value = 0, min = 0)
+        }
+    })
+}
+
+
+activate_selector_if_checked <- function(name, input, output, session) {
+    observeEvent(input[[paste0(name, "_tick")]], {
+        if (!input[[paste0(name, "_tick")]]) {
+            disable(name)
+            updateSelectInput(session, name, selected = input[[name]][0])
+        } else {
+            enable(name)
+            updateSelectInput(session, name, selected = input[[name]][1])
+        }
+    })
+}

--- a/shiny/equationer/server.R
+++ b/shiny/equationer/server.R
@@ -1,0 +1,133 @@
+shinyServer(function(input, output, session) {
+
+
+# covariates ------------------------------------------------------
+
+
+    activate_numeric_if_checked("adjusted_weight", input, output, session)
+    activate_numeric_if_checked("age", input, output, session)
+    activate_numeric_if_checked("air_humidity", input, output, session)
+    activate_numeric_if_checked("air_temperature", input, output, session)
+    activate_numeric_if_checked("albumin_mg_dl", input, output, session)
+    activate_numeric_if_checked("bmi", input, output, session)
+    activate_numeric_if_checked("glucose_g_dl", input, output, session)
+    activate_numeric_if_checked("height", input, output, session)
+    activate_numeric_if_checked("lbm", input, output, session)
+    activate_numeric_if_checked("lta", input, output, session)
+    activate_numeric_if_checked("mean_chest_skinfold", input, output, session)
+    activate_numeric_if_checked("subscapular_skinfold", input, output, session)
+    activate_numeric_if_checked("surface_area", input, output, session)
+    activate_numeric_if_checked("weight", input, output, session)
+    activate_numeric_if_checked("wrist_circumference", input, output, session)
+
+    activate_selector_if_checked("menopausal", input, output, session)
+
+# strata ----------------------------------------------------------
+
+    activate_selector_if_checked("bmi_class", input, output, session)
+    activate_selector_if_checked("bmi_greater_21", input, output, session)
+    activate_selector_if_checked("diabetic", input, output, session)
+    activate_selector_if_checked("ethnicity", input, output, session)
+    activate_selector_if_checked("hf", input, output, session)
+    activate_selector_if_checked("sex", input, output, session)
+
+
+# Evaluate --------------------------------------------------------
+
+    observeEvent(input[["eval"]], {
+        cov <- list(
+            input[["adjusted_weight"]],
+            input[["age"]],
+            input[["air_humidity"]],
+            input[["air_temperature"]],
+            input[["albumin_mg_dl"]],
+            input[["bmi"]],
+            input[["glucose_g_dl"]],
+            input[["height"]],
+            1L,
+            input[["lbm"]],
+            input[["lta"]],
+            input[["mean_chest_skinfold"]],
+            input[["menopausal"]],
+            input[["subscapular_skinfold"]],
+            input[["surface_area"]],
+            input[["weight"]],
+            input[["wrist_circumference"]]
+        ) %>%
+            setNames(sort(get_covariates(reer))) %>%
+            .[c(
+                input[["adjusted_weight_tick"]],
+                input[["age_tick"]],
+                input[["air_humidity_tick"]],
+                input[["air_temperature_tick"]],
+                input[["albumin_mg_dl_tick"]],
+                input[["bmi_tick"]],
+                input[["glucose_g_dl_tick"]],
+                input[["height_tick"]],
+                TRUE,
+                input[["lbm_tick"]],
+                input[["lta_tick"]],
+                input[["mean_chest_skinfold_tick"]],
+                input[["menopausal_tick"]],
+                input[["subscapular_skinfold_tick"]],
+                input[["surface_area_tick"]],
+                input[["weight_tick"]]
+            )]
+
+cat("\nCOV\n")
+cat(str(cov))
+
+        strata <- list(
+            input[["bmi_class"]],
+            input[["bmi_greater_21"]],
+            input[["diabetic"]],
+            input[["ethnicity"]],
+            input[["hf"]],
+            input[["sex"]]
+        ) %>%
+            setNames(c(
+                "bmi_class", "bmi_greater_21", "diabetic", "ethnicity",
+                "hf", "sex"
+            )) %>%
+            .[c(
+                input[["bmi_class_tick"]],
+                input[["bmi_greater_21_tick"]],
+                input[["diabetic_tick"]],
+                input[["ethnicity_tick"]],
+                input[["hf_tick"]],
+                input[["sex_tick"]]
+            )]
+
+cat("\nSTRATA\n")
+cat(str(strata))
+
+
+
+        dots <- as.data.frame(c(cov, strata)) %>%
+            dplyr::mutate_if(is.factor, as.character) %>%
+            dplyr::mutate_if(is.character, ~ifelse(. %in% c("TRUE", "FALSE"), as.logical(.), .))
+
+cat("\ndots\n")
+cat(str(dots))
+
+        outcomes <- c("bee", "bmr", "eee", "ree", "rmr")[c(
+            input[["bee_tick"]], input[["bmr_tick"]],
+            input[["eee_tick"]], input[["ree_tick"]],
+            input[["rmr_tick"]]
+        )]
+
+
+cat("\noutcomes\n")
+cat(str(outcomes))
+
+        res <- evaluate_at(reer, dots, .outcome = outcomes) %>%
+            dplyr::mutate(estimation = round(estimation, 2))
+
+        output[["res_tab"]] <- renderDT(res,
+            options = list(filter = "top")
+        )
+
+
+    })
+
+})

--- a/shiny/equationer/ui.R
+++ b/shiny/equationer/ui.R
@@ -1,0 +1,141 @@
+shinyUI(fluidPage(
+    # Use shiny js to disable fields
+    useShinyjs(),
+    title = "equationer",
+    titlePanel("Equations of Energy Requirements"),
+
+
+    # Sidebar with a slider input for number of bins
+    sidebarLayout(
+        sidebarPanel(
+
+                    strong("COVARIATES"),
+
+            fluidRow(
+                column(4, checkboxInput("adjusted_weight_tick", "Adjusted weight (Kg)", FALSE)),
+                column(8, numericInput("adjusted_weight", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("age_tick", "Age (years)", FALSE)),
+                column(8, numericInput("age", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("air_humidity_tick", "Air humidity", FALSE)),
+                column(8, numericInput("air_humidity", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("air_temperature_tick", "Air temperature (C)", FALSE)),
+                column(8, numericInput("air_temperature", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("albumin_mg_dl_tick", "Albumin (mg/dl)", FALSE)),
+                column(8, numericInput("albumin_mg_dl", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("bmi_tick", "BMI", FALSE)),
+                column(8, numericInput("bmi", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("glucose_g_dl_tick", "Glucose (g/dl)", FALSE)),
+                column(8, numericInput("glucose_g_dl", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("height_tick", "Height (cm)", FALSE)),
+                column(8, numericInput("height", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("lbm_tick", "Lean Body Mass (Kg)", FALSE)),
+                column(8, numericInput("lbm", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("lta_tick", "Leasure Time Activity (hours)", FALSE)),
+                column(8, numericInput("lta", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("mean_chest_skinfold_tick", "Chest skinfold (mean, mm)", FALSE)),
+                column(8, numericInput("mean_chest_skinfold", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("menopausal_tick", "Menopausal stage (1-3)", FALSE)),
+                column(8, selectInput("menopausal", "", c(1L, 2L, 3L)))
+            ),
+            fluidRow(
+                column(4, checkboxInput("subscapular_skinfold_tick", "Subscapular skinfold (mean, mm)", FALSE)),
+                column(8, numericInput("subscapular_skinfold", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("surface_area_tick", "Body surface area (cm^2)", FALSE)),
+                column(8, numericInput("surface_area", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("weight_tick", "Weight (Kg)", FALSE)),
+                column(8, numericInput("weight", "", 0, 0))
+            ),
+            fluidRow(
+                column(4, checkboxInput("wrist_circumference_tick", "Wrist circumference (cm)", FALSE)),
+                column(8, numericInput("wrist_circumference", "", 0, 0))
+            ),
+
+
+
+
+                    hr(),
+                    strong("STRATA (uncheck to do not use the strata, i.e. it does not means 'no'/'false'!)"),
+
+            fluidRow(
+                column(4, checkboxInput("bmi_class_tick", "BMI class", FALSE)),
+                column(8, selectInput("bmi_class", "", get_strata(reer)[["bmi_class"]]))
+            ),
+            fluidRow(
+                column(4, checkboxInput("bmi_greater_21_tick", "BMI grater than 21?", FALSE)),
+                column(8, selectInput("bmi_greater_21", "", get_strata(reer)[["bmi_greater_21"]]))
+            ),
+            fluidRow(
+                column(4, checkboxInput("diabetic_tick", "Is diabetic?", FALSE)),
+                column(8, selectInput("diabetic", "", get_strata(reer)[["diabetic"]]))
+            ),
+            fluidRow(
+                column(4, checkboxInput("ethnicity_tick", "Ethnicity", FALSE)),
+                column(8, selectInput("ethnicity", "", get_strata(reer)[["ethnicity"]]))
+            ),
+            fluidRow(
+                column(4, checkboxInput("hf_tick", "is NYHA III or IV?", FALSE)),
+                column(8, selectInput("hf", "", get_strata(reer)[["hf"]]))
+            ),
+            fluidRow(
+                column(4, checkboxInput("sex_tick", "Sex", FALSE)),
+                column(8, selectInput("sex", "", get_strata(reer)[["sex"]]))
+            ),
+
+
+
+
+                    hr(),
+                    strong("OUTCOMES"),
+
+            fluidRow(
+                column(4, checkboxInput("bee_tick", "BEE", TRUE)),
+                column(4, checkboxInput("eee_tick", "EEE", TRUE)),
+                column(4, checkboxInput("ree_tick", "REE", TRUE))
+            ),
+            fluidRow(
+                column(4, checkboxInput("bmr_tick", "BMR", TRUE)),
+                column(4),
+                column(4, checkboxInput("rmr_tick", "RMR", TRUE))
+            ),
+
+
+
+            hr(),
+
+
+            actionButton("eval", "Evaluate equations")
+
+        ),
+
+
+        mainPanel(dataTableOutput("res_tab"))
+    )
+
+
+))

--- a/tests/testthat/helper-eq.R
+++ b/tests/testthat/helper-eq.R
@@ -130,7 +130,7 @@ var_output <- c(
     "eq_group", "reference"
 )
 var_output_weight <- c(
-    "age", "bmi", "weight", "sex", "nyha", "outcome", "estimation",
+    "age", "bmi", "sex", "nyha", "outcome", "estimation",
     "eq_name", "eq_group", "reference"
 )
 

--- a/tests/testthat/test-evaluate_at.R
+++ b/tests/testthat/test-evaluate_at.R
@@ -68,7 +68,7 @@ test_that("correct evaluation for eq", {
 })
 
 
-test_that("eror works for eq", {
+test_that("error works for eq", {
     expect_error(
         evaluate_at(eq_test, age = 38, weight = "heavy"),
         "are included"
@@ -279,10 +279,11 @@ test_that("eqs_bag works with data that include missing strata", {
 
 
 test_that("Works with only age and BMI on reer", {
-    expect_is(
+    expect_equal(
         suppressWarnings(
-            evaluate_at(reer, intercept = 1, age = 50, bmi = 21, sex = "female")
+            evaluate_at(reer, age = 50, bmi = 21, sex = "female") %>%
+                nrow()
         ),
-        "tbl_df"
+        1L
     )
 })

--- a/tests/testthat/test-evaluate_at.R
+++ b/tests/testthat/test-evaluate_at.R
@@ -17,7 +17,7 @@ test_that("correct columns", {
     )
     expect_equal(
         names(evaluated1),
-        c("age", "bmi", "weight", "outcome", "estimation", "eq_name")
+        c("age", "bmi", "outcome", "estimation", "eq_name")
     )
     expect_equal(
         names(evaluated2),
@@ -62,8 +62,6 @@ test_that("correct evaluation for eq", {
     expect_equal(evaluated[["eq_name"]], "eq_test")
 
 
-    expect_equal(evaluated1[["weight"]], 81)
-
     expect_equal(evaluated2[["sex"]], "male")
     expect_equal(evaluated2[["nyha"]], 1)
 
@@ -73,7 +71,7 @@ test_that("correct evaluation for eq", {
 test_that("eror works for eq", {
     expect_error(
         evaluate_at(eq_test, age = 38, weight = "heavy"),
-        "numeric"
+        "are included"
     )
 
     expect_error(evaluate_at(eq_test, 38), "names")
@@ -251,9 +249,9 @@ test_that("works with data frames", {
             names(evaluate_at(eqs_bag_test, more_patients))
         ),
         c(
-            "id", "age", "bmi", "weight", "sex", "nyha", "outcome",
+            "age", "bmi", "sex", "nyha", "outcome",
             "estimation", "eq_name", "eq_group", "reference",
-            ".source_row"
+            "weight", ".source_row"
         )
     )
 
@@ -263,4 +261,18 @@ test_that("works with data frames", {
 test_that("works with multiple posible matching variables", {
     expect_is(evaluated_multimatch_bag, "tbl_df")
     expect_equal(nrow(evaluated_multimatch_bag), 4)
+})
+
+
+
+
+test_that("eqs_bag works with data that include missing strata", {
+    expect_is(
+        suppressWarnings(
+            evaluate_at(eqs_bag_test,
+                age = 1, bmi = 1, weight = 1, diabetics = FALSE
+            )
+        ),
+        "tbl_df"
+    )
 })

--- a/tests/testthat/test-evaluate_at.R
+++ b/tests/testthat/test-evaluate_at.R
@@ -276,3 +276,13 @@ test_that("eqs_bag works with data that include missing strata", {
         "tbl_df"
     )
 })
+
+
+test_that("Works with only age and BMI on reer", {
+    expect_is(
+        suppressWarnings(
+            evaluate_at(reer, intercept = 1, age = 50, bmi = 21, sex = "female")
+        ),
+        "tbl_df"
+    )
+})


### PR DESCRIPTION
* added warning if not sufficient input are supplied (#11)
* remove the needs to provide the intercept
* fix bug found by DB that prevents `evaluate_at()` to work if
  no strata are provided to a bag (#10)
* fix bug that prevents `evaluate_at()` to work if data supplied 
  strata not in the eqs_bag.
